### PR TITLE
fix(ci): beta-workflow auf PR-close umstellen (#482)

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -21,11 +21,9 @@ name: "RF: Beta Release Pipeline"
 #   beta-release.yml  → release/v* → Beta
 #   release.yml       → master     → Stable
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches: ['release/v*']
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
 
 # Serialisiert Beta-Releases pro release/v*-Branch — verhindert Race Condition
 # analog zu alpha-release.yml (Issue #55).
@@ -43,6 +41,9 @@ permissions:
 jobs:
   beta-release:
     name: Beta Release
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'fix/')
     runs-on: ubuntu-latest
     steps:
       # GitHub App Token ZUERST (#406) — siehe Kommentar in basic.yml
@@ -103,7 +104,7 @@ jobs:
         if: steps.release.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BODY: ${{ github.event_name == 'pull_request' && github.event.pull_request.body || '' }}
         shell: bash
         run: |
           ISSUE_NUMBERS=$(printf '%s' "$PR_BODY" | grep -oiE '(closes?|closed|fix(es|ed)?|resolves?|resolved|refs?)[ :]*#[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' | sort -u)


### PR DESCRIPTION
## Kontext
Dieser Hotfix adressiert den bekannten Train-Blocker aus K.Actions.ReleaseFlow Issue #482 (Beta-Workflow auf `release/v*` läuft in einen Context-Mismatch).

## Änderung
- `beta-release.yml` Trigger von `push` auf `pull_request: closed` umgestellt.
- Job-Guard ergänzt: nur bei gemergten `fix/*`-Branches wird Beta ausgeführt.
- PR-Body-Expression robust gemacht, um Context-Warnungen zu vermeiden.

## Wirkung
- Verhindert den deterministischen Fehler beim Push auf `release/v*`.
- Nutzt PR-Kontext für `Get-ReleaseContext`.
- Reduziert CI-Noise durch irrelevante Runs.

## Hinweis
Die Datei ist auto-managed; Upstream-Fix in ReleaseFlow bleibt weiterhin erforderlich.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimierte Beta-Release-Trigger: Releases werden nun gezielt bei geschlossenen Pull Requests mit standardisierten Branch-Namen ausgelöst, statt automatisch bei jedem Push.
  * Erhöhte Zuverlässigkeit: Behobenes Problem mit fehlenden Metadaten im Release-Prozess, das zu Parsing-Fehlern führen könnte.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->