### PR TITLE
chore(release): dev/v1.13.1 -> release/v1.13.1

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -24,6 +24,29 @@ permissions:
   contents: read
 
 jobs:
+  unit-tests:
+    name: Pester Unit-Tests (Hook Guards)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Pester Unit-Tests
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Install-Module Pester -Force -Scope CurrentUser -SkipPublisherCheck
+          $env:CLAUDE_PLUGIN_ROOT = (Join-Path ([System.IO.Path]::GetTempPath()) 'kagents-ci')
+          $result = Invoke-Pester `
+            -Path plugins/kagents/hooks/tests/ `
+            -PassThru `
+            -Output Detailed
+
+          if ($result.FailedCount -gt 0) {
+            Write-Output "::error::$($result.FailedCount) Pester Unit-Test(s) fehlgeschlagen."
+            exit 1
+          }
+          Write-Output "Pester: $($result.PassedCount) Tests bestanden, $($result.FailedCount) fehlgeschlagen."
+
   quality-gate:
     name: quality-gate
     runs-on: ubuntu-latest
@@ -112,4 +135,5 @@ jobs:
             echo "|-------|--------|"
             echo "| PSScriptAnalyzer (plugins/kagents) | ${{ job.status }} |"
             echo "| Plugin-Manifest-Validation | ${{ job.status }} |"
+            echo "| Pester Unit-Tests (Hook Guards) | siehe Job 'unit-tests' |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -34,7 +34,7 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          Install-Module Pester -Force -Scope CurrentUser -SkipPublisherCheck
+          Install-Module Pester -Force -Scope CurrentUser -SkipPublisherCheck -MinimumVersion 5.6 -MaximumVersion 5.99
           $env:CLAUDE_PLUGIN_ROOT = (Join-Path ([System.IO.Path]::GetTempPath()) 'kagents-ci')
           $result = Invoke-Pester `
             -Path plugins/kagents/hooks/tests/ `

--- a/plugins/kagents/hooks/tests/conventional-commit-guard.Tests.ps1
+++ b/plugins/kagents/hooks/tests/conventional-commit-guard.Tests.ps1
@@ -3,7 +3,7 @@ Set-StrictMode -Version Latest
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    $env:CLAUDE_PLUGIN_ROOT = Join-Path $env:TEMP "kagents-test-$(New-Guid)"
+    $env:CLAUDE_PLUGIN_ROOT = Join-Path ([System.IO.Path]::GetTempPath()) "kagents-test-$(New-Guid)"
     $script:GuardPath = Join-Path $PSScriptRoot '..' 'conventional-commit-guard.ps1'
     Remove-Item Env:KAGENTS_COMMIT_BYPASS -ErrorAction SilentlyContinue
 

--- a/plugins/kagents/hooks/tests/conventional-commit-guard.Tests.ps1
+++ b/plugins/kagents/hooks/tests/conventional-commit-guard.Tests.ps1
@@ -1,0 +1,83 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $env:CLAUDE_PLUGIN_ROOT = Join-Path $env:TEMP "kagents-test-$(New-Guid)"
+    $script:GuardPath = Join-Path $PSScriptRoot '..' 'conventional-commit-guard.ps1'
+    Remove-Item Env:KAGENTS_COMMIT_BYPASS -ErrorAction SilentlyContinue
+
+    function script:Invoke-Guard([string]$Command, [string]$ToolName = 'Bash') {
+        @{
+            tool_name  = $ToolName
+            session_id = 'test'
+            tool_input = @{ command = $Command }
+        } | ConvertTo-Json -Compress -Depth 10 |
+            pwsh -NoProfile -NonInteractive -File $script:GuardPath 2>$null
+    }
+}
+
+Describe 'conventional-commit-guard' {
+    Context 'Gueltige Commit-Nachrichten durchgelassen' {
+        It 'laesst feat(scope): desc mit Bullet durch' {
+            $cmd = 'git commit -m "feat(scope): kurze beschreibung' + "`n`n" + '- was geaendert"'
+            Invoke-Guard $cmd | Should -BeNullOrEmpty
+        }
+        It 'laesst fix: desc ohne Scope durch (Scope optional)' {
+            $cmd = 'git commit -m "fix: korrektur eines fehlers' + "`n`n" + '- fehler behoben"'
+            Invoke-Guard $cmd | Should -BeNullOrEmpty
+        }
+        It 'laesst chore: mit Ref # durch' {
+            $cmd = 'git commit -m "chore: abhaengigkeiten aktualisiert' + "`n`n" + '- bump auf v2' + "`n`n" + 'Ref #42"'
+            Invoke-Guard $cmd | Should -BeNullOrEmpty
+        }
+    }
+    Context 'Ungueltige Commit-Nachrichten blockiert' {
+        It 'blockiert Freitext ohne Type' {
+            $result = Invoke-Guard 'git commit -m "random text"' | ConvertFrom-Json
+            $result.decision | Should -Be 'block'
+            $result.reason   | Should -Match 'Type'
+        }
+        It 'blockiert Closes # im Body' {
+            $cmd = 'git commit -m "feat(api): neue route' + "`n`n" + '- route hinzugefuegt' + "`n`n" + 'Closes #10"'
+            $result = Invoke-Guard $cmd | ConvertFrom-Json
+            $result.decision | Should -Be 'block'
+            $result.reason   | Should -Match 'Closes'
+        }
+        It 'blockiert fehlenden Bulletpoint-Body' {
+            $cmd = 'git commit -m "feat(ui): button hinzugefuegt"'
+            $result = Invoke-Guard $cmd | ConvertFrom-Json
+            $result.decision | Should -Be 'block'
+            $result.reason   | Should -Match 'Bulletpoints'
+        }
+        It 'blockiert Description mit Grossbuchstabe' {
+            $cmd = 'git commit -m "feat(ui): Gross am Anfang' + "`n`n" + '- etwas"'
+            $result = Invoke-Guard $cmd | ConvertFrom-Json
+            $result.decision | Should -Be 'block'
+            $result.reason   | Should -Match 'Kleinbuchstabe'
+        }
+    }
+    Context 'Nicht-git-commit Kommandos ignoriert' {
+        It 'laesst git status durch' {
+            Invoke-Guard 'git status' | Should -BeNullOrEmpty
+        }
+        It 'laesst git commit --file durch' {
+            Invoke-Guard 'git commit --file msg.txt' | Should -BeNullOrEmpty
+        }
+    }
+    Context 'Nicht-Bash Tools werden ignoriert' {
+        It 'laesst git commit bei Write-Tool durch' {
+            Invoke-Guard 'git commit -m "random text"' -ToolName 'Write' | Should -BeNullOrEmpty
+        }
+    }
+    Context 'Break-Glass' {
+        It 'laesst ungueltige Nachricht durch wenn KAGENTS_COMMIT_BYPASS=1' {
+            $env:KAGENTS_COMMIT_BYPASS = '1'
+            try {
+                Invoke-Guard 'git commit -m "random text"' | Should -BeNullOrEmpty
+            } finally {
+                Remove-Item Env:KAGENTS_COMMIT_BYPASS -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/plugins/kagents/hooks/tests/crossplatform-lint-guard.Tests.ps1
+++ b/plugins/kagents/hooks/tests/crossplatform-lint-guard.Tests.ps1
@@ -1,0 +1,86 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $env:CLAUDE_PLUGIN_ROOT = Join-Path $env:TEMP "kagents-test-$(New-Guid)"
+    $script:GuardPath = Join-Path $PSScriptRoot '..' 'crossplatform-lint-guard.ps1'
+    Remove-Item Env:KAGENTS_LINT_BYPASS  -ErrorAction SilentlyContinue
+    Remove-Item Env:KAGENTS_LINT_FULL    -ErrorAction SilentlyContinue
+
+    $script:ValidContent = "#Requires -Version 7.4`nSet-StrictMode -Version Latest`nWrite-Output 'hello'"
+
+    function script:Invoke-Guard([string]$FilePath, [string]$Content, [string]$ToolName = 'Write') {
+        @{
+            tool_name  = $ToolName
+            session_id = 'test'
+            tool_input = @{ file_path = $FilePath; content = $Content }
+        } | ConvertTo-Json -Compress -Depth 10 |
+            pwsh -NoProfile -NonInteractive -File $script:GuardPath 2>$null
+    }
+}
+
+Describe 'crossplatform-lint-guard' {
+    Context 'Verbotenes Write-Cmdlet erkannt' {
+        It 'blockiert verbotenes Write-Cmdlet in PS1-Inhalt' {
+            # Laufzeit-Verkettung — nie als Literal im Quellcode
+            $wh = 'Write-' + 'Host'
+            $content = "#Requires -Version 7.4`nSet-StrictMode -Version Latest`n$wh 'test'"
+            $result = Invoke-Guard 'script.ps1' $content | ConvertFrom-Json
+            $result.decision | Should -Be 'block'
+            $result.reason   | Should -Match $wh
+        }
+        It 'laesst Write-Output durch' {
+            Invoke-Guard 'script.ps1' $script:ValidContent | Should -BeNullOrEmpty
+        }
+    }
+    Context 'Hardcoded Windows-Pfad erkannt' {
+        It 'blockiert Backslash-Pfad in PS1-Inhalt' {
+            # Laufzeit-Verkettung — nie als Literal im Quellcode
+            $wp = 'C:' + '\temp\file.txt'
+            $content = "#Requires -Version 7.4`nSet-StrictMode -Version Latest`n`$p = '$wp'"
+            $result = Invoke-Guard 'script.ps1' $content | ConvertFrom-Json
+            $result.decision | Should -Be 'block'
+            $result.reason   | Should -Match 'Windows-Pfad'
+        }
+    }
+    Context 'Fehlende Header erkannt' {
+        It 'blockiert fehlenden #Requires -Version Header' {
+            $content = "Set-StrictMode -Version Latest`nWrite-Output 'ok'"
+            $result = Invoke-Guard 'script.ps1' $content | ConvertFrom-Json
+            $result.decision | Should -Be 'block'
+            $result.reason   | Should -Match 'Requires'
+        }
+        It 'blockiert fehlenden Set-StrictMode' {
+            $content = "#Requires -Version 7.4`nWrite-Output 'ok'"
+            $result = Invoke-Guard 'script.ps1' $content | ConvertFrom-Json
+            $result.decision | Should -Be 'block'
+            $result.reason   | Should -Match 'StrictMode'
+        }
+    }
+    Context 'Nicht-PS1 Dateien werden ignoriert' {
+        It 'laesst .txt-Datei mit Verstoss durch' {
+            $wh = 'Write-' + 'Host'
+            Invoke-Guard 'readme.txt' "$wh 'test'" | Should -BeNullOrEmpty
+        }
+    }
+    Context 'Nicht-Write Tools werden ignoriert' {
+        It 'laesst Verstoss bei Bash-Tool durch' {
+            $wh = 'Write-' + 'Host'
+            $content = "#Requires -Version 7.4`nSet-StrictMode -Version Latest`n$wh 'test'"
+            Invoke-Guard 'script.ps1' $content -ToolName 'Bash' | Should -BeNullOrEmpty
+        }
+    }
+    Context 'Break-Glass' {
+        It 'laesst Verstoss durch wenn KAGENTS_LINT_BYPASS=1' {
+            $env:KAGENTS_LINT_BYPASS = '1'
+            try {
+                $wh = 'Write-' + 'Host'
+                $content = "#Requires -Version 7.4`nSet-StrictMode -Version Latest`n$wh 'test'"
+                Invoke-Guard 'script.ps1' $content | Should -BeNullOrEmpty
+            } finally {
+                Remove-Item Env:KAGENTS_LINT_BYPASS -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/plugins/kagents/hooks/tests/crossplatform-lint-guard.Tests.ps1
+++ b/plugins/kagents/hooks/tests/crossplatform-lint-guard.Tests.ps1
@@ -3,7 +3,7 @@ Set-StrictMode -Version Latest
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    $env:CLAUDE_PLUGIN_ROOT = Join-Path $env:TEMP "kagents-test-$(New-Guid)"
+    $env:CLAUDE_PLUGIN_ROOT = Join-Path ([System.IO.Path]::GetTempPath()) "kagents-test-$(New-Guid)"
     $script:GuardPath = Join-Path $PSScriptRoot '..' 'crossplatform-lint-guard.ps1'
     Remove-Item Env:KAGENTS_LINT_BYPASS  -ErrorAction SilentlyContinue
     Remove-Item Env:KAGENTS_LINT_FULL    -ErrorAction SilentlyContinue

--- a/plugins/kagents/hooks/tests/destructive-command-guard.Tests.ps1
+++ b/plugins/kagents/hooks/tests/destructive-command-guard.Tests.ps1
@@ -1,0 +1,76 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $env:CLAUDE_PLUGIN_ROOT = Join-Path $env:TEMP "kagents-test-$(New-Guid)"
+    $script:GuardPath = Join-Path $PSScriptRoot '..' 'destructive-command-guard.ps1'
+    Remove-Item Env:KAGENTS_DESTRUCTIVE_BYPASS -ErrorAction SilentlyContinue
+
+    function script:Invoke-Guard([string]$Command, [string]$ToolName = 'Bash') {
+        @{
+            tool_name  = $ToolName
+            session_id = 'test'
+            tool_input = @{ command = $Command }
+        } | ConvertTo-Json -Compress -Depth 10 |
+            pwsh -NoProfile -NonInteractive -File $script:GuardPath 2>$null
+    }
+}
+
+Describe 'destructive-command-guard' {
+    Context 'Destruktive Kommandos blockiert' {
+        It 'blockiert rm -rf /' {
+            $result = Invoke-Guard 'rm -rf /' | ConvertFrom-Json
+            $result.decision | Should -Be 'block'
+            $result.reason   | Should -Match 'rm -rf /'
+        }
+        It 'blockiert git clean -fd' {
+            # git clean -fd ist nicht in den Block-Patterns; ls -la ebenfalls
+            # Das Guard blockiert: rm -rf /, rm -rf ~, git push --force, git reset --hard etc.
+            # git clean -fd ist kein blockiertes Muster — durchgelassen
+            Invoke-Guard 'git clean -fd' | Should -BeNullOrEmpty
+        }
+        It 'blockiert git reset --hard' {
+            $result = Invoke-Guard 'git reset --hard' | ConvertFrom-Json
+            $result.decision | Should -Be 'block'
+            $result.reason   | Should -Match 'git reset --hard'
+        }
+        It 'blockiert DROP TABLE' {
+            $result = Invoke-Guard 'DROP TABLE users' | ConvertFrom-Json
+            $result.decision | Should -Be 'block'
+            $result.reason   | Should -Match 'DROP TABLE'
+        }
+    }
+    Context 'Sichere Kommandos durchgelassen' {
+        It 'laesst ls -la durch' {
+            Invoke-Guard 'ls -la' | Should -BeNullOrEmpty
+        }
+        It 'laesst rm -rf node_modules durch (Allowlist)' {
+            Invoke-Guard 'rm -rf node_modules' | Should -BeNullOrEmpty
+        }
+        It 'laesst git push --force-with-lease durch (Allowlist)' {
+            Invoke-Guard 'git push --force-with-lease' | Should -BeNullOrEmpty
+        }
+    }
+    Context 'Nicht-Bash Tools werden ignoriert' {
+        It 'laesst rm -rf / durch wenn Tool nicht Bash ist' {
+            @{
+                tool_name  = 'Write'
+                session_id = 'test'
+                tool_input = @{ command = 'rm -rf /' }
+            } | ConvertTo-Json -Compress -Depth 10 |
+                pwsh -NoProfile -NonInteractive -File $script:GuardPath 2>$null |
+                Should -BeNullOrEmpty
+        }
+    }
+    Context 'Break-Glass' {
+        It 'laesst rm -rf / durch wenn KAGENTS_DESTRUCTIVE_BYPASS=1' {
+            $env:KAGENTS_DESTRUCTIVE_BYPASS = '1'
+            try {
+                Invoke-Guard 'rm -rf /' | Should -BeNullOrEmpty
+            } finally {
+                Remove-Item Env:KAGENTS_DESTRUCTIVE_BYPASS -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/plugins/kagents/hooks/tests/destructive-command-guard.Tests.ps1
+++ b/plugins/kagents/hooks/tests/destructive-command-guard.Tests.ps1
@@ -3,7 +3,7 @@ Set-StrictMode -Version Latest
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    $env:CLAUDE_PLUGIN_ROOT = Join-Path $env:TEMP "kagents-test-$(New-Guid)"
+    $env:CLAUDE_PLUGIN_ROOT = Join-Path ([System.IO.Path]::GetTempPath()) "kagents-test-$(New-Guid)"
     $script:GuardPath = Join-Path $PSScriptRoot '..' 'destructive-command-guard.ps1'
     Remove-Item Env:KAGENTS_DESTRUCTIVE_BYPASS -ErrorAction SilentlyContinue
 
@@ -24,12 +24,6 @@ Describe 'destructive-command-guard' {
             $result.decision | Should -Be 'block'
             $result.reason   | Should -Match 'rm -rf /'
         }
-        It 'blockiert git clean -fd' {
-            # git clean -fd ist nicht in den Block-Patterns; ls -la ebenfalls
-            # Das Guard blockiert: rm -rf /, rm -rf ~, git push --force, git reset --hard etc.
-            # git clean -fd ist kein blockiertes Muster — durchgelassen
-            Invoke-Guard 'git clean -fd' | Should -BeNullOrEmpty
-        }
         It 'blockiert git reset --hard' {
             $result = Invoke-Guard 'git reset --hard' | ConvertFrom-Json
             $result.decision | Should -Be 'block'
@@ -42,6 +36,9 @@ Describe 'destructive-command-guard' {
         }
     }
     Context 'Sichere Kommandos durchgelassen' {
+        It 'laesst git clean -fd durch' {
+            Invoke-Guard 'git clean -fd' | Should -BeNullOrEmpty
+        }
         It 'laesst ls -la durch' {
             Invoke-Guard 'ls -la' | Should -BeNullOrEmpty
         }

--- a/plugins/kagents/hooks/tests/post_tool_call.Tests.ps1
+++ b/plugins/kagents/hooks/tests/post_tool_call.Tests.ps1
@@ -3,7 +3,7 @@ Set-StrictMode -Version Latest
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    $script:PluginRoot = Join-Path $env:TEMP "kagents-test-$(New-Guid)"
+    $script:PluginRoot = Join-Path ([System.IO.Path]::GetTempPath()) "kagents-test-$(New-Guid)"
     $env:CLAUDE_PLUGIN_ROOT = $script:PluginRoot
     $script:GuardPath = Join-Path $PSScriptRoot '..' 'post_tool_call.ps1'
     $script:LogFile   = Join-Path $script:PluginRoot 'logs' "$(Get-Date -Format 'yyyy-MM-dd').jsonl"

--- a/plugins/kagents/hooks/tests/post_tool_call.Tests.ps1
+++ b/plugins/kagents/hooks/tests/post_tool_call.Tests.ps1
@@ -1,0 +1,96 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $script:PluginRoot = Join-Path $env:TEMP "kagents-test-$(New-Guid)"
+    $env:CLAUDE_PLUGIN_ROOT = $script:PluginRoot
+    $script:GuardPath = Join-Path $PSScriptRoot '..' 'post_tool_call.ps1'
+    $script:LogFile   = Join-Path $script:PluginRoot 'logs' "$(Get-Date -Format 'yyyy-MM-dd').jsonl"
+
+    function script:Invoke-Hook([hashtable]$HookData) {
+        $HookData | ConvertTo-Json -Compress -Depth 10 |
+            pwsh -NoProfile -NonInteractive -File $script:GuardPath 2>$null
+        # Kurz warten, damit das Dateisystem die Log-Datei flusht
+        Start-Sleep -Milliseconds 50
+    }
+
+    function script:Get-LastLogEntry {
+        if (-not (Test-Path $script:LogFile)) { return $null }
+        $lastLine = Get-Content $script:LogFile -Encoding utf8 -ErrorAction SilentlyContinue |
+            Select-Object -Last 1
+        if (-not $lastLine) { return $null }
+        $lastLine | ConvertFrom-Json
+    }
+}
+
+AfterAll {
+    Remove-Item $script:PluginRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'post_tool_call' {
+    BeforeEach {
+        if (Test-Path $script:LogFile) { Remove-Item $script:LogFile -Force }
+    }
+
+    Context 'Fehler-Fall: is_error = true' {
+        It 'loggt post_tool_use_failure-Event bei is_error:true' {
+            Invoke-Hook @{
+                tool_name     = 'Bash'
+                session_id    = 'test-session'
+                tool_input    = @{ command = 'ls' }
+                tool_response = @{ is_error = $true; error = 'Permission denied' }
+                agent_type    = 'claude'
+            }
+            $entry = Get-LastLogEntry
+            $entry | Should -Not -BeNullOrEmpty
+            $entry.event    | Should -Be 'post_tool_use_failure'
+            $entry.tool_name | Should -Be 'Bash'
+            $entry.error    | Should -Be 'Permission denied'
+        }
+    }
+    Context 'Erfolgs-Fall: kein Fehler' {
+        It 'loggt post_tool_use-Event bei normalem Response' {
+            Invoke-Hook @{
+                tool_name     = 'Read'
+                session_id    = 'test-session'
+                tool_input    = @{ file_path = '/tmp/test.txt' }
+                tool_response = @{ content = 'file content' }
+                agent_type    = 'claude'
+            }
+            $entry = Get-LastLogEntry
+            $entry | Should -Not -BeNullOrEmpty
+            $entry.event     | Should -Be 'post_tool_use'
+            $entry.tool_name | Should -Be 'Read'
+        }
+    }
+    Context 'Fehler-Fall: error-Key im Response' {
+        It 'loggt Failure-Event bei error-Key in tool_response' {
+            Invoke-Hook @{
+                tool_name     = 'Write'
+                session_id    = 'test-session'
+                tool_input    = @{ file_path = '/tmp/x.txt' }
+                tool_response = @{ error = 'File not found' }
+                agent_type    = 'claude'
+            }
+            $entry = Get-LastLogEntry
+            $entry | Should -Not -BeNullOrEmpty
+            $entry.event | Should -Be 'post_tool_use_failure'
+            $entry.error | Should -Be 'File not found'
+        }
+    }
+    Context 'Kein tool_response — Erfolg' {
+        It 'loggt post_tool_use ohne tool_response' {
+            Invoke-Hook @{
+                tool_name  = 'Bash'
+                session_id = 'test-session'
+                tool_input = @{ command = 'pwd' }
+                agent_type = 'claude'
+            }
+            $entry = Get-LastLogEntry
+            $entry | Should -Not -BeNullOrEmpty
+            $entry.event      | Should -Be 'post_tool_use'
+            $entry.has_response | Should -Be $false
+        }
+    }
+}

--- a/plugins/kagents/hooks/tests/releaseflow-guardrail.Tests.ps1
+++ b/plugins/kagents/hooks/tests/releaseflow-guardrail.Tests.ps1
@@ -1,0 +1,104 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $env:CLAUDE_PLUGIN_ROOT = Join-Path $env:TEMP "kagents-test-$(New-Guid)"
+    $script:GuardPath = Join-Path $PSScriptRoot '..' 'releaseflow-guardrail.ps1'
+    Remove-Item Env:RELEASEFLOW_BYPASS -ErrorAction SilentlyContinue
+
+    function script:New-TempReleaseFlowRepo([string]$BranchName) {
+        $tmpDir = Join-Path $env:TEMP "kagents-rf-$(New-Guid)"
+        New-Item -ItemType Directory -Path $tmpDir | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $tmpDir '.github') | Out-Null
+        Set-Content -Path (Join-Path $tmpDir '.github' 'releaseflow.json') -Value '{}' -Encoding utf8
+        git -C $tmpDir init --quiet 2>$null | Out-Null
+        git -C $tmpDir config user.email 'test@test.com' 2>$null | Out-Null
+        git -C $tmpDir config user.name 'Test' 2>$null | Out-Null
+        Set-Content -Path (Join-Path $tmpDir 'README.md') -Value '# test' -Encoding utf8
+        git -C $tmpDir add . 2>$null | Out-Null
+        git -C $tmpDir commit -m 'init' --quiet 2>$null | Out-Null
+        if ($BranchName -ne 'master') {
+            git -C $tmpDir checkout -b $BranchName --quiet 2>$null | Out-Null
+        }
+        return $tmpDir
+    }
+
+    $script:FeatureRepo  = New-TempReleaseFlowRepo 'feature/test-feature'
+    $script:ReleaseRepo  = New-TempReleaseFlowRepo 'release/v1.0.0'
+    $script:NonRFRepo    = Join-Path $env:TEMP "kagents-norf-$(New-Guid)"
+    New-Item -ItemType Directory -Path $script:NonRFRepo | Out-Null
+
+    function script:Invoke-Guard([string]$Command, [string]$Cwd, [string]$ToolName = 'Bash') {
+        @{
+            tool_name  = $ToolName
+            session_id = 'test'
+            cwd        = $Cwd
+            tool_input = @{ command = $Command }
+        } | ConvertTo-Json -Compress -Depth 10 |
+            pwsh -NoProfile -NonInteractive -File $script:GuardPath 2>$null
+    }
+}
+
+AfterAll {
+    Remove-Item $script:FeatureRepo  -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item $script:ReleaseRepo  -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item $script:NonRFRepo    -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'releaseflow-guardrail' {
+    Context 'Direkter master-Merge blockiert' {
+        It 'blockiert gh pr create --base master von Feature-Branch' {
+            $output = Invoke-Guard 'gh pr create --base master --title "Test"' $script:FeatureRepo
+            $result = $output | ConvertFrom-Json
+            $result.decision | Should -Be 'block'
+            $result.reason   | Should -Match 'ReleaseFlow-Guardrail'
+        }
+    }
+    Context 'Release-Branch auf master erlaubt' {
+        It 'laesst gh pr create --base master von release/v* durch' {
+            Invoke-Guard 'gh pr create --base master --title "Stable"' $script:ReleaseRepo |
+                Should -BeNullOrEmpty
+        }
+    }
+    Context 'Feature-Branch auf dev/* erlaubt' {
+        It 'laesst gh pr create --base dev/v1.0.0 durch' {
+            Invoke-Guard 'gh pr create --base dev/v1.0.0 --title "Feature"' $script:FeatureRepo |
+                Should -BeNullOrEmpty
+        }
+    }
+    Context 'Kein ReleaseFlow-Repo — keine Pruefung' {
+        It 'laesst gh pr create --base master in Nicht-RF-Repo durch' {
+            Invoke-Guard 'gh pr create --base master --title "Test"' $script:NonRFRepo |
+                Should -BeNullOrEmpty
+        }
+    }
+    Context 'Nicht-Bash Tools werden ignoriert' {
+        It 'laesst gh pr create bei Write-Tool durch' {
+            @{
+                tool_name  = 'Write'
+                session_id = 'test'
+                cwd        = $script:FeatureRepo
+                tool_input = @{ command = 'gh pr create --base master' }
+            } | ConvertTo-Json -Compress -Depth 10 |
+                pwsh -NoProfile -NonInteractive -File $script:GuardPath 2>$null |
+                Should -BeNullOrEmpty
+        }
+    }
+    Context 'Normale Bash-Kommandos nicht betroffen' {
+        It 'laesst git status durch' {
+            Invoke-Guard 'git status' $script:FeatureRepo | Should -BeNullOrEmpty
+        }
+    }
+    Context 'Break-Glass' {
+        It 'laesst blockiertes Kommando durch wenn RELEASEFLOW_BYPASS=1' {
+            $env:RELEASEFLOW_BYPASS = '1'
+            try {
+                Invoke-Guard 'gh pr create --base master --title "Test"' $script:FeatureRepo |
+                    Should -BeNullOrEmpty
+            } finally {
+                Remove-Item Env:RELEASEFLOW_BYPASS -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/plugins/kagents/hooks/tests/releaseflow-guardrail.Tests.ps1
+++ b/plugins/kagents/hooks/tests/releaseflow-guardrail.Tests.ps1
@@ -3,12 +3,12 @@ Set-StrictMode -Version Latest
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    $env:CLAUDE_PLUGIN_ROOT = Join-Path $env:TEMP "kagents-test-$(New-Guid)"
+    $env:CLAUDE_PLUGIN_ROOT = Join-Path ([System.IO.Path]::GetTempPath()) "kagents-test-$(New-Guid)"
     $script:GuardPath = Join-Path $PSScriptRoot '..' 'releaseflow-guardrail.ps1'
     Remove-Item Env:RELEASEFLOW_BYPASS -ErrorAction SilentlyContinue
 
     function script:New-TempReleaseFlowRepo([string]$BranchName) {
-        $tmpDir = Join-Path $env:TEMP "kagents-rf-$(New-Guid)"
+        $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "kagents-rf-$(New-Guid)"
         New-Item -ItemType Directory -Path $tmpDir | Out-Null
         New-Item -ItemType Directory -Path (Join-Path $tmpDir '.github') | Out-Null
         Set-Content -Path (Join-Path $tmpDir '.github' 'releaseflow.json') -Value '{}' -Encoding utf8
@@ -26,7 +26,7 @@ BeforeAll {
 
     $script:FeatureRepo  = New-TempReleaseFlowRepo 'feature/test-feature'
     $script:ReleaseRepo  = New-TempReleaseFlowRepo 'release/v1.0.0'
-    $script:NonRFRepo    = Join-Path $env:TEMP "kagents-norf-$(New-Guid)"
+    $script:NonRFRepo    = Join-Path ([System.IO.Path]::GetTempPath()) "kagents-norf-$(New-Guid)"
     New-Item -ItemType Directory -Path $script:NonRFRepo | Out-Null
 
     function script:Invoke-Guard([string]$Command, [string]$Cwd, [string]$ToolName = 'Bash') {

--- a/plugins/kagents/hooks/tests/secret-scanner.Tests.ps1
+++ b/plugins/kagents/hooks/tests/secret-scanner.Tests.ps1
@@ -3,7 +3,7 @@ Set-StrictMode -Version Latest
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    $env:CLAUDE_PLUGIN_ROOT = Join-Path $env:TEMP "kagents-test-$(New-Guid)"
+    $env:CLAUDE_PLUGIN_ROOT = Join-Path ([System.IO.Path]::GetTempPath()) "kagents-test-$(New-Guid)"
     $script:GuardPath = Join-Path $PSScriptRoot '..' 'secret-scanner.ps1'
     Remove-Item Env:KAGENTS_SECRET_BYPASS -ErrorAction SilentlyContinue
 

--- a/plugins/kagents/hooks/tests/secret-scanner.Tests.ps1
+++ b/plugins/kagents/hooks/tests/secret-scanner.Tests.ps1
@@ -1,0 +1,62 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $env:CLAUDE_PLUGIN_ROOT = Join-Path $env:TEMP "kagents-test-$(New-Guid)"
+    $script:GuardPath = Join-Path $PSScriptRoot '..' 'secret-scanner.ps1'
+    Remove-Item Env:KAGENTS_SECRET_BYPASS -ErrorAction SilentlyContinue
+
+    function script:Invoke-Guard([hashtable]$HookData) {
+        ($HookData | ConvertTo-Json -Compress -Depth 10) |
+            pwsh -NoProfile -NonInteractive -File $script:GuardPath 2>$null
+    }
+
+    # Pattern per Laufzeit-Verkettung — nie als Literal im Quellcode
+    $script:FakeGhPat     = 'ghp_' + ('A' * 36)
+    $script:FakeOpenAiKey = 'sk-' + ('a' * 48)
+}
+
+Describe 'secret-scanner' {
+    Context 'GitHub PAT erkannt' {
+        It 'blockiert GitHub PAT im Bash-Kommando' {
+            $output = Invoke-Guard @{
+                tool_name  = 'Bash'
+                session_id = 'test'
+                tool_input = @{ command = "echo $($script:FakeGhPat)" }
+            }
+            $result = $output | ConvertFrom-Json
+            $result.decision | Should -Be 'block'
+            $result.reason   | Should -Match 'GitHub PAT'
+        }
+    }
+    Context 'OpenAI Key erkannt' {
+        It 'blockiert OpenAI Key im Write-Content' {
+            $output = Invoke-Guard @{
+                tool_name  = 'Write'
+                session_id = 'test'
+                tool_input = @{ file_path = 'config.txt'; content = "KEY=$($script:FakeOpenAiKey)" }
+            }
+            $result = $output | ConvertFrom-Json
+            $result.decision | Should -Be 'block'
+            $result.reason   | Should -Match 'OpenAI'
+        }
+    }
+    Context 'Harmloser Input' {
+        It 'laesst normales Bash-Kommando durch' {
+            Invoke-Guard @{ tool_name = 'Bash'; session_id = 'test'
+                tool_input = @{ command = 'git status' } } | Should -BeNullOrEmpty
+        }
+    }
+    Context 'Break-Glass' {
+        It 'laesst PAT durch wenn KAGENTS_SECRET_BYPASS=1' {
+            $env:KAGENTS_SECRET_BYPASS = '1'
+            try {
+                Invoke-Guard @{ tool_name = 'Bash'; session_id = 'test'
+                    tool_input = @{ command = "echo $($script:FakeGhPat)" } } | Should -BeNullOrEmpty
+            } finally {
+                Remove-Item Env:KAGENTS_SECRET_BYPASS -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}


### PR DESCRIPTION
## v1.13.1 — Stream B: Pester Unit-Tests fuer alle 6 Hook Guards

Foerderung von dev/v1.13.1 nach release/v1.13.1.

- 6 neue Pester-Unit-Test-Dateien (43 Tests total)
- quality-gate.yml: Pester Unit-Test-Job ergaenzt
- Advisor-Fixes: GetTempPath(), Pester-Version gepinnt, Test-Inkonsistenz behoben

Ref #36
