### PR TITLE
fix(workflows): label-step grep exit 1 unter pipefail abfangen

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -105,7 +105,12 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         shell: bash
         run: |
-          ISSUE_NUMBERS=$(printf '%s' "$PR_BODY" | grep -oiE '(closes?|closed|fix(es|ed)?|resolves?|resolved|refs?)[ :]*#[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' | sort -u)
+          # grep liefert exit code 1 wenn keine Treffer gefunden werden — das ist normales
+          # POSIX-Verhalten und kein Fehler. Ohne "|| true" wuerde GitHub Actions' Shell-Option
+          # "-eo pipefail" (bash --noprofile --norc -eo pipefail) die Pipeline als Fehler werten
+          # und das Script hier abbrechen, bevor "if [ -z ... ]" ueberhaupt laeuft.
+          # Quelle: BashFAQ/105 — echte Assignments propagieren den Exit-Code der Subshell.
+          ISSUE_NUMBERS=$(printf '%s' "$PR_BODY" | grep -oiE '(closes?|closed|fix(es|ed)?|resolves?|resolved|refs?)[ :]*#[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' | sort -u || true)
 
           if [ -z "$ISSUE_NUMBERS" ]; then
             echo "No closing keywords found — no issues to label."


### PR DESCRIPTION
## Summary

- `|| true` an grep-Pipeline-Ende verhindert `set -e`-Abbruch bei leeren PR-Bodies
- `grep` exit 1 (kein Match) wurde fälschlicherweise als Fehler gewertet
- Kommentar erklärt BashFAQ/105-Mechanismus für künftige Leser

## Root Cause

Unter `bash --noprofile --norc -eo pipefail {0}` (GitHub Actions Standard):
`grep` liefert exit 1 wenn keine Treffer → Pipeline exit 1 → echtes Assignment propagiert exit 1 → `set -e` triggert → Script bricht ab bevor `if [ -z "$ISSUE_NUMBERS" ]` läuft.

Upstream Bug: GrexyLoco/K.Actions.ReleaseFlow#490

## Test plan

- [ ] Im nächsten fix/* Beta-Run ohne Closing-Keywords: `echo "No closing keywords found"` erscheint im Log
- [ ] Label-Step endet mit exit 0

Closes #490 (upstream)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Die Beta-Release-Workflow wurde stabilisiert. Sie behandelt nun ordnungsgemäß Fälle, in denen keine Probleme in Commits referenziert werden, und schlägt nicht mehr unerwartet fehl. Die Extraktionslogik wurde robuster gestaltet und schlägt nicht mehr fehl, wenn die Suche nach Issues keine Treffer findet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->