### PR TITLE
fix(consumer-hooks): pfad nach Issue-131 korrigieren

### DIFF
--- a/.github/workflows/consumer-hooks.yml
+++ b/.github/workflows/consumer-hooks.yml
@@ -63,7 +63,7 @@ jobs:
           $newVersion = $env:NEW_VERSION
 
           # 1. Source of Truth: plugin.json
-          $pluginPath = Join-Path 'plugins' 'kagents' '.github' 'plugin.json'
+          $pluginPath = Join-Path 'plugins' 'kagents' '.github' 'plugin' 'plugin.json'
           $plugin = Get-Content $pluginPath -Raw | ConvertFrom-Json
           $plugin.version = $newVersion
           $plugin | ConvertTo-Json -Depth 10 | Set-Content $pluginPath -Encoding utf8
@@ -96,7 +96,7 @@ jobs:
           git config user.name "k-releaseflow[bot]"
           git config user.email "k-releaseflow[bot]@users.noreply.github.com"
 
-          git add plugins/kagents/.github/plugin.json .github/plugin/marketplace.json
+          git add plugins/kagents/.github/plugin/plugin.json .github/plugin/marketplace.json
           if [ -f ".claude-plugin/marketplace.json" ]; then
             git add .claude-plugin/marketplace.json
           fi


### PR DESCRIPTION
## Was

`consumer-hooks.yml` schlug nach dem Stable-Release v1.15.0 fehl, weil `plugins/kagents/.github/plugin.json` nicht mehr existiert.

## Warum

Issue #131 (Plugin-Strukturbereinigung) hat die Datei nach `plugins/kagents/.github/plugin/plugin.json` verschoben. Der Workflow wurde dabei nicht mitgepflegt.

## Änderungen

- Zeile 66: `Join-Path ... '.github' 'plugin.json'` → `'.github' 'plugin' 'plugin.json'`
- Zeile 99: `git add plugins/kagents/.github/plugin.json` → `plugins/kagents/.github/plugin/plugin.json`

Closes #139