### PR TITLE
fix: settings.local.json zur gitignore hinzufügen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Thumbs.db
 
 # K.Agents Laufzeit-Logs
 plugins/kagents/logs/
+
+# Claude Code lokal-spezifische Einstellungen
+.claude/settings.local.json


### PR DESCRIPTION
- Claude Code machine-spezifische Einstellungen sind lokal und privat
- Nicht in Source Control tracken

🤖 Generated with [Claude Code](https://claude.com/claude-code)