### PR TITLE
fix(marketplace): .claude-plugin/marketplace.json erstellen, name auf kagents korrigieren

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "K.Agents",
+  "name": "kagents",
   "description": "Spezialisierte Agenten fuer .NET/Azure Entwicklung mit Orchestrator, Hooks und MCP-Integration",
   "owner": {
-    "name": "GrexyLoco"
+    "name": "GrexyLoco",
+    "email": "noreply@grexyloco.dev"
   },
   "plugins": [
     {
       "name": "kagents",
-      "version": "v1.14.0",
-      "description": "15 spezialisierte Agenten mit Orchestrator fuer .NET 10, C# 14, Blazor, MAUI, PowerShell Core, Azure und GitHub Actions",
+      "version": "v1.15.2",
+      "description": "14 spezialisierte AI-Agents und 27 Skills fuer .NET 10, C# 14, Blazor, MAUI, PowerShell Core, Azure und GitHub Actions",
       "source": "./plugins/kagents",
       "category": "development",
       "homepage": "https://github.com/GrexyLoco/K.Agents"

--- a/README.md
+++ b/README.md
@@ -375,6 +375,18 @@ _* Automation Architect delegiert an powershell-engineer für Script-Implementie
 
 Siehe [CONTRIBUTING.md](CONTRIBUTING.md) für Richtlinien.
 
+### Kritische Repo-Dateien
+
+#### `.claude-plugin/marketplace.json`
+
+Claude Code sucht beim Hinzufügen eines GitHub-Repos als Marketplace zwingend unter `.claude-plugin/marketplace.json`. Ohne diese Datei schlägt die Installation fehl:
+
+```text
+Plugin "kagents" not found in marketplace "kagents"
+```
+
+Das Verzeichnis `.claude-plugin/` darf **nicht entfernt** werden — auch nicht bei Strukturbereinigungen. Hintergrund: [Issue #149](https://github.com/GrexyLoco/K.Agents/issues/149), [Claude Code Docs](https://code.claude.com/docs/en/discover-plugins).
+
 ## Danksagung
 
 OSS-Skills adaptiert von:


### PR DESCRIPTION
## Zusammenfassung

- `.claude-plugin/marketplace.json` am korrekten Pfad erstellt (Claude Code erwartet diese Datei bei GitHub-Installation)
- `marketplace.json` aus dem Repo-Root entfernt (war am falschen Ort)
- `name` von `"K.Agents"` auf `"kagents"` korrigiert (kebab-case-Pflicht)
- `README.md`: Hinweis auf `.claude-plugin/marketplace.json` unter "Kritische Repo-Dateien" ergänzt

## Geschlossene Issues

Closes #148
Closes #149

## Testplan

- [ ] `/plugin marketplace add GrexyLoco/K.Agents` schlägt nicht mehr mit "Marketplace name must be kebab-case" fehl
- [ ] `/plugin install kagents@kagents` findet das Plugin
- [ ] `.claude-plugin/marketplace.json` ist im Git-Tree vorhanden